### PR TITLE
fix(bag_parser): use 3D geometry conversion for panden

### DIFF
--- a/bag/bag_parser.py
+++ b/bag/bag_parser.py
@@ -123,13 +123,7 @@ def parse_xml_file(file_xml, tag_name, data_init, object_tag_name, db_fields, db
 def geometry_to_wgs84(rows, is_3d=False):
     for i, row in enumerate(rows):
         if is_3d:
-            # bag_geometry_3d_to_wgs_geojson expects raw space-separated text,
-            # but parse_xml_file wraps the posList value in [...] on read.
-            # Strip the outer brackets before passing.
-            geom = row['geometry']
-            if geom.startswith('[') and geom.endswith(']'):
-                geom = geom[1:-1]
-            row['geometry'] = utils.bag_geometry_3d_to_wgs_geojson(geom)
+            row['geometry'] = utils.bag_geometry_3d_rings_to_wgs_geojson(row['geometry'])
         else:
             row['geometry'] = utils.bag_geometry_to_wgs_geojson(row['geometry'])
 

--- a/bag/bag_parser.py
+++ b/bag/bag_parser.py
@@ -111,16 +111,27 @@ def parse_xml_file(file_xml, tag_name, data_init, object_tag_name, db_fields, db
     # Add geometry
     if has_geometry:
         if config.parse_geometries:
-            db_rows = geometry_to_wgs84(db_rows)
+            # Panden use 3D coordinates (srsDimension="3") in the BAG XML;
+            # all other types (Woonplaats, Ligplaats, Standplaats) use 2D.
+            db_rows = geometry_to_wgs84(db_rows, is_3d=(tag_name == 'Pand'))
         else:
             db_rows = geometry_to_empty(db_rows)
 
     return db_rows
 
 
-def geometry_to_wgs84(rows):
+def geometry_to_wgs84(rows, is_3d=False):
     for i, row in enumerate(rows):
-        row['geometry'] = utils.bag_geometry_to_wgs_geojson(row['geometry'])
+        if is_3d:
+            # bag_geometry_3d_to_wgs_geojson expects raw space-separated text,
+            # but parse_xml_file wraps the posList value in [...] on read.
+            # Strip the outer brackets before passing.
+            geom = row['geometry']
+            if geom.startswith('[') and geom.endswith(']'):
+                geom = geom[1:-1]
+            row['geometry'] = utils.bag_geometry_3d_to_wgs_geojson(geom)
+        else:
+            row['geometry'] = utils.bag_geometry_to_wgs_geojson(row['geometry'])
 
     return rows
 

--- a/utils.py
+++ b/utils.py
@@ -190,6 +190,29 @@ def bag_geometry_to_wgs_geojson(geometry):
     return coordinates_wgs
 
 
+def bag_geometry_3d_rings_to_wgs_geojson(geometry):
+    """Convert a 3D multi-ring geometry string to GeoJSON polygon coordinates.
+
+    The parser stores each posList as [x y z x y z ...] and concatenates
+    multiple rings with commas: [ring1],[ring2]. This function handles both
+    single and multi-ring pand geometries.
+    """
+    rings = geometry.split('],[')
+    result_rings = []
+    for ring in rings:
+        ring = ring.strip('[]')
+        tokens = ring.split()
+        ring_coords = ''
+        it = iter(tokens)
+        for x, y, z in zip(it, it, it):
+            lat, lon = rijksdriehoek.rijksdriehoek_to_wgs84(float(x), float(y))
+            if ring_coords:
+                ring_coords += ','
+            ring_coords += '[' + str(lon) + ',' + str(lat) + ']'
+        result_rings.append('[' + ring_coords + ']')
+    return '[' + ','.join(result_rings) + ']'
+
+
 def bag_geometry_3d_to_wgs_geojson(coordinates_rd):
     coordinates_rd = coordinates_rd.split()
     coordinates_wgs = ''


### PR DESCRIPTION
BAG pand XML uses srsDimension="3". The V88 refactor lost the pand-specific call to bag_geometry_3d_to_wgs_geojson(), causing the 2D function to misread triplets as pairs and corrupt all but the first coordinate.

Restores correct behaviour by passing the object type into geometry_to_wgs84() so panden take the 3D path.

Fixes #25.